### PR TITLE
Change env var name back

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -20,7 +20,7 @@ module.exports = {
 
   test: {
     client: "pg",
-    connection: process.env.DB_TEST_URL,
+    connection: `postgres://localhost/${process.env.DB_TEST_NAME}`,
     pool: {
       min: 2,
       max: 10,


### PR DESCRIPTION
Keeping this real simple for now, want to see if it fixes the GitHub Actions build process failing to connect.